### PR TITLE
Fix heap buffer overflow in QubeServoPendulum analog read

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,9 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 [extensions]
 QuanserInterfacePythonCallExt = ["PythonCall"]
 
+[workspace]
+projects = ["test", "lib", "examples"]
+
 [compat]
 CEnum = "0.4.2, 0.5"
 ControlSystemIdentification = "2.6"

--- a/src/qube_servo.jl
+++ b/src/qube_servo.jl
@@ -152,7 +152,7 @@ initialize(p::QubeServoSimulator) = nothing
         digital_channel_write = UInt32[0],
         encoder_channel       = UInt32[0, 1],
         analog_channel_write  = UInt32[0],
-        analog_channel_read   = UInt32[0],
+        analog_channel_read   = UInt32[],
         encoder_read_buffer   = zeros(Int32, 2),
         analog_read_buffer    = zeros(Int32, 0),
     )


### PR DESCRIPTION
## Summary
- **Fixed a heap buffer overflow** in `QubeServoPendulum`: `analog_channel_read` was `UInt32[0]` (requesting 1 channel read) while `analog_read_buffer` was `zeros(Int32, 0)` (0 elements). Every call to `measure()` caused `hil_read_analog` to write 8 bytes (Float64) past the end of the zero-length buffer, corrupting heap memory. This manifested as the arm encoder reporting phantom rotation while the arm was physically stationary.
- Added workspace entry to root `Project.toml`

## Test plan
- [x] Verified fix resolves phantom arm rotation on physical Qube Servo hardware
- [ ] Run existing tests with `] test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)